### PR TITLE
Fixed issues where cleaner was only cleaing one registry.

### DIFF
--- a/Src/Metrics.Tests/Metrics/EventMetricTests.cs
+++ b/Src/Metrics.Tests/Metrics/EventMetricTests.cs
@@ -67,34 +67,34 @@ namespace Metrics.Tests.Metrics
             evnt.Value.Events.Count.Should().Be(1);
             evnt.Reset();
             evnt.Value.Events.Count.Should().Be(0);
-		}
+        }
 
-		[Fact]
-		public void EventMetric_CanBeRecordedOnMultipleThreads()
-		{
-			const int threadCount = 16;
-			const long iterations = 1000 * 100;
+        [Fact]
+        public void EventMetric_CanBeRecordedOnMultipleThreads()
+        {
+            const int threadCount = 16;
+            const long iterations = 1000 * 100;
 
-			List<Thread> threads = new List<Thread>();
-			TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
+            List<Thread> threads = new List<Thread>();
+            TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
 
-			for (int i = 0; i < threadCount; i++)
-			{
-				threads.Add(new Thread(s =>
-				{
-					tcs.Task.Wait();
-					for (long j = 0; j < iterations; j++)
-					{
-						evnt.Record();
-					}
-				}));
-			}
+            for (int i = 0; i < threadCount; i++)
+            {
+                threads.Add(new Thread(s =>
+                {
+                    tcs.Task.Wait();
+                    for (long j = 0; j < iterations; j++)
+                    {
+                        evnt.Record();
+                    }
+                }));
+            }
 
-			threads.ForEach(t => t.Start());
-			tcs.SetResult(0);
-			threads.ForEach(t => t.Join());
+            threads.ForEach(t => t.Start());
+            tcs.SetResult(0);
+            threads.ForEach(t => t.Join());
 
-			evnt.Value.EventsCopy.Count.Should().Be(threadCount * (int)iterations);
-		}
-	}
+            evnt.Value.EventsCopy.Count.Should().Be(threadCount * (int)iterations);
+        }
+    }
 }

--- a/Src/Metrics.Tests/Reporting/EventMetricsCleanerTest.cs
+++ b/Src/Metrics.Tests/Reporting/EventMetricsCleanerTest.cs
@@ -11,16 +11,16 @@ using Xunit;
 namespace Metrics.Tests.Reporting
 {
     public class EventMetricsCleanerTest
-	{
-		private const string MetricName = "test";
-		private const string MetricNameType = "test.event";
-		private readonly string metricNameTypeTags = MetricIdentifier.Calculate("test.event");
+    {
+        private const string MetricName = "test";
+        private const string MetricNameType = "test.event";
+        private readonly string metricNameTypeTags = MetricIdentifier.Calculate("test.event");
 
-		public void ResetCleaner()
+        public void ResetCleaner()
         {
             EventMetricsCleaner.Clear();
-			EventMetricsCleaner.ResetInterval();
-		}
+            EventMetricsCleaner.ResetInterval();
+        }
 
         [Fact]
         public void StartsWithZeroReports()
@@ -77,7 +77,7 @@ namespace Metrics.Tests.Reporting
         {
             var registry = new DefaultMetricsRegistry();
             registry.Event(MetricName, () => { return new EventMetric(); }, MetricTags.None);
-			var reportIndex = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
+            var reportIndex = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
 
             EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex, registry.DataProvider.Events);
 
@@ -91,7 +91,7 @@ namespace Metrics.Tests.Reporting
         {
             var registry = new DefaultMetricsRegistry();
             registry.Event(MetricName, () => { return new EventMetric(); }, MetricTags.None);
-			var reportIndex1 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
+            var reportIndex1 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
             var reportIndex2 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
             EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex1, registry.DataProvider.Events);
             EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex2, registry.DataProvider.Events);
@@ -118,10 +118,10 @@ namespace Metrics.Tests.Reporting
 
         [Fact]
         public void Clean_OnlyRemovesEventDetailItems_ThatHaveBeenReportedByAllReports()
-		{
-			const string context = "";
-			var registry = new DefaultMetricsRegistry();
-			EventMetricsCleaner.AddRegistry(context, registry);
+        {
+            const string context = "";
+            var registry = new DefaultMetricsRegistry();
+            EventMetricsCleaner.AddRegistry(context, registry);
             var timer = new MockTimer();
             EventMetricsCleaner.EnableTestTimer(timer);
 
@@ -130,7 +130,7 @@ namespace Metrics.Tests.Reporting
             var metric = new EventMetric();
             registry.Event(MetricName, () => { return metric; }, MetricTags.None);
 
-			metric.Record();
+            metric.Record();
             EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex1, registry.DataProvider.Events);
             metric.Record();
             EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex2, registry.DataProvider.Events);
@@ -140,19 +140,19 @@ namespace Metrics.Tests.Reporting
 
             timer.OnTimerCallback();
 
-			var registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
-			registryCounts[context].Should().Be(1);
+            var registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
+            registryCounts[context].Should().Be(1);
 
             ResetCleaner();
         }
 
         [Fact]
         public void Clean_IgnoresReportsThatHaveNotReportedAnyEvents()
-		{
-			const string context = "";
-			var registry = new DefaultMetricsRegistry();
-			EventMetricsCleaner.AddRegistry(context, registry);
-			var timer = new MockTimer();
+        {
+            const string context = "";
+            var registry = new DefaultMetricsRegistry();
+            EventMetricsCleaner.AddRegistry(context, registry);
+            var timer = new MockTimer();
             EventMetricsCleaner.EnableTestTimer(timer);
 
             var reportIndex1 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
@@ -167,120 +167,120 @@ namespace Metrics.Tests.Reporting
             EventMetricsCleaner.GetReportsReportedEventDetailCount(reportIndex2, metricNameTypeTags).Should().Be(0);
 
             timer.OnTimerCallback();
-			
-			var registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
-	        registryCounts[context].Should().Be(0);
-			
-			ResetCleaner();
+            
+            var registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
+            registryCounts[context].Should().Be(0);
+            
+            ResetCleaner();
         }
 
         [Fact]
         public void Clean_WithNoReportsRegistered_RemovesAllEvents()
-		{
-			const string context = "";
-			var registry = new DefaultMetricsRegistry();
-			EventMetricsCleaner.AddRegistry(context, registry);
-			var timer = new MockTimer();
+        {
+            const string context = "";
+            var registry = new DefaultMetricsRegistry();
+            EventMetricsCleaner.AddRegistry(context, registry);
+            var timer = new MockTimer();
             EventMetricsCleaner.EnableTestTimer(timer);
 
             var metric = new EventMetric();
             registry.Event(MetricName, () => { return metric; }, MetricTags.None);
 
-			metric.Record();
             metric.Record();
             metric.Record();
-			var registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
-			registryCounts[context].Should().Be(3);
+            metric.Record();
+            var registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
+            registryCounts[context].Should().Be(3);
 
-			timer.OnTimerCallback();
-			
-			registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
-			registryCounts[context].Should().Be(0);
+            timer.OnTimerCallback();
+            
+            registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
+            registryCounts[context].Should().Be(0);
 
-			ResetCleaner();
-		}
+            ResetCleaner();
+        }
 
-		[Fact]
-		public void Clean_WithAllReportsFilteringOutEvents_RemovesAllEvents()
-		{
-			const string context = "";
-			var registry = new DefaultMetricsRegistry();
-			EventMetricsCleaner.AddRegistry(context, registry);
-			var timer = new MockTimer();
-			EventMetricsCleaner.EnableTestTimer(timer);
+        [Fact]
+        public void Clean_WithAllReportsFilteringOutEvents_RemovesAllEvents()
+        {
+            const string context = "";
+            var registry = new DefaultMetricsRegistry();
+            EventMetricsCleaner.AddRegistry(context, registry);
+            var timer = new MockTimer();
+            EventMetricsCleaner.EnableTestTimer(timer);
 
-			var reportIndex1 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
-			var reportIndex2 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
-			var metric = new EventMetric();
-			registry.Event(MetricName, () => { return metric; }, MetricTags.None);
-			metric.Record();
-			metric.Record();
-			metric.Record();
-			EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex1, new List<EventValueSource>());
-			EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex2, new List<EventValueSource>());
+            var reportIndex1 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
+            var reportIndex2 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
+            var metric = new EventMetric();
+            registry.Event(MetricName, () => { return metric; }, MetricTags.None);
+            metric.Record();
+            metric.Record();
+            metric.Record();
+            EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex1, new List<EventValueSource>());
+            EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex2, new List<EventValueSource>());
 
-			EventMetricsCleaner.GetReportsReportedEventDetailCount(reportIndex1, MetricNameType).Should().Be(0);
-			EventMetricsCleaner.GetReportsReportedEventDetailCount(reportIndex2, MetricNameType).Should().Be(0);
-			var registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
-			registryCounts[context].Should().Be(3);
+            EventMetricsCleaner.GetReportsReportedEventDetailCount(reportIndex1, MetricNameType).Should().Be(0);
+            EventMetricsCleaner.GetReportsReportedEventDetailCount(reportIndex2, MetricNameType).Should().Be(0);
+            var registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
+            registryCounts[context].Should().Be(3);
 
-			timer.OnTimerCallback();
+            timer.OnTimerCallback();
 
-			registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
-			registryCounts[context].Should().Be(0);
+            registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts(MetricNameType);
+            registryCounts[context].Should().Be(0);
 
-			ResetCleaner();
-		}
+            ResetCleaner();
+        }
 
-		[Fact]
-		public void Clean_WithMultipleRegistriesInSeparateContexts_RemovesEvents()
-		{
-			const string ctx1 = "ctx1";
-			var registry1 = new DefaultMetricsRegistry();
-			EventMetricsCleaner.AddRegistry(ctx1, registry1);
+        [Fact]
+        public void Clean_WithMultipleRegistriesInSeparateContexts_RemovesEvents()
+        {
+            const string ctx1 = "ctx1";
+            var registry1 = new DefaultMetricsRegistry();
+            EventMetricsCleaner.AddRegistry(ctx1, registry1);
 
-			const string ctx2 = "ctx2";
-			var registry2 = new DefaultMetricsRegistry();
-			EventMetricsCleaner.AddRegistry(ctx2, registry2);
+            const string ctx2 = "ctx2";
+            var registry2 = new DefaultMetricsRegistry();
+            EventMetricsCleaner.AddRegistry(ctx2, registry2);
 
-			var timer = new MockTimer();
-			EventMetricsCleaner.EnableTestTimer(timer);
+            var timer = new MockTimer();
+            EventMetricsCleaner.EnableTestTimer(timer);
 
-			var reportIndex1 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
-			var metric1 = new EventMetric();
-			registry1.Event("test1", () => { return metric1; }, MetricTags.None);
-			metric1.Record();
-			metric1.Record();
-			metric1.Record();
-			EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex1, registry1.DataProvider.Events);
+            var reportIndex1 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
+            var metric1 = new EventMetric();
+            registry1.Event("test1", () => { return metric1; }, MetricTags.None);
+            metric1.Record();
+            metric1.Record();
+            metric1.Record();
+            EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex1, registry1.DataProvider.Events);
 
-			var reportIndex2 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
-			var metric2 = new EventMetric();
-			registry2.Event("test2", () => { return metric2; }, MetricTags.None);
-			metric2.Record();
-			metric2.Record();
-			EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex2, registry2.DataProvider.Events);
-			
-			var registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts("test1.event");
-			registryCounts[ctx1].Should().Be(3);
-			registryCounts[ctx2].Should().Be(0);
-			registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts("test2.event");
-			registryCounts[ctx1].Should().Be(0);
-			registryCounts[ctx2].Should().Be(2);
+            var reportIndex2 = EventMetricsCleaner.RegisterReport(new TimeSpan(0, 0, 0, 60));
+            var metric2 = new EventMetric();
+            registry2.Event("test2", () => { return metric2; }, MetricTags.None);
+            metric2.Record();
+            metric2.Record();
+            EventMetricsCleaner.UpdateTotalReportedEvents(reportIndex2, registry2.DataProvider.Events);
+            
+            var registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts("test1.event");
+            registryCounts[ctx1].Should().Be(3);
+            registryCounts[ctx2].Should().Be(0);
+            registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts("test2.event");
+            registryCounts[ctx1].Should().Be(0);
+            registryCounts[ctx2].Should().Be(2);
 
-			timer.OnTimerCallback();
+            timer.OnTimerCallback();
 
-			registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts("test1.event");
-			registryCounts[ctx1].Should().Be(0);
-			registryCounts[ctx2].Should().Be(0);
-			registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts("test2.event");
-			registryCounts[ctx1].Should().Be(0);
-			registryCounts[ctx2].Should().Be(0);
+            registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts("test1.event");
+            registryCounts[ctx1].Should().Be(0);
+            registryCounts[ctx2].Should().Be(0);
+            registryCounts = EventMetricsCleaner.GetRegistryEventDetailCounts("test2.event");
+            registryCounts[ctx1].Should().Be(0);
+            registryCounts[ctx2].Should().Be(0);
 
-			ResetCleaner();
-		}
+            ResetCleaner();
+        }
 
-		public class MockTimer : ITimer
+        public class MockTimer : ITimer
         {
             public event TimerEventHandler Tick;
 

--- a/Src/Metrics.Tests/Reporting/EventMetricsCleanerTest.cs
+++ b/Src/Metrics.Tests/Reporting/EventMetricsCleanerTest.cs
@@ -20,7 +20,7 @@ namespace Metrics.Tests.Reporting
         public void ResetCleaner()
         {
             EventMetricsCleaner.ContextRegistries.Clear();
-            EventMetricsCleaner.ReportEvntCounts.Clear();
+            EventMetricsCleaner.ReportEventCounts.Clear();
             EventMetricsCleaner.ResetInterval();
         }
 
@@ -286,12 +286,12 @@ namespace Metrics.Tests.Reporting
 
         private static int GetReportsEventCount(int reportIdentifier)
         {
-            return EventMetricsCleaner.ReportEvntCounts[reportIdentifier].Count;
+            return EventMetricsCleaner.ReportEventCounts[reportIdentifier].Count;
         }
 
         private static int GetReportsReportedEventDetailCount(int reportIdentifier, string eventMetricIdentifier)
         {
-            var eventCount = EventMetricsCleaner.ReportEvntCounts[reportIdentifier].FirstOrDefault(e => e.EventMetricIdentifier == eventMetricIdentifier);
+            var eventCount = EventMetricsCleaner.ReportEventCounts[reportIdentifier].FirstOrDefault(e => e.EventMetricIdentifier == eventMetricIdentifier);
             return eventCount?.TotalEventsReported ?? 0;
         }
 

--- a/Src/Metrics.Tests/Reporting/EventMetricsCleanerTest.cs
+++ b/Src/Metrics.Tests/Reporting/EventMetricsCleanerTest.cs
@@ -25,14 +25,6 @@ namespace Metrics.Tests.Reporting
         }
 
         [Fact]
-        public void StartsWithZeroReports()
-        {
-            ResetCleaner();
-
-            EventMetricsCleaner.TotalReports.Should().Be(0);
-        }
-
-        [Fact]
         public void DefaultIntervalIsGreaterThanZero()
         {
             ResetCleaner();

--- a/Src/Metrics/Core/BaseMetricsContext.cs
+++ b/Src/Metrics/Core/BaseMetricsContext.cs
@@ -19,7 +19,7 @@ namespace Metrics.Core
         protected BaseMetricsContext(string context, MetricsRegistry registry, MetricsBuilder metricsBuilder, Func<DateTime> timestampProvider)
         {
             this.registry = registry;
-            EventMetricsCleaner.Registry = registry;
+            EventMetricsCleaner.AddRegistry(context, registry);
             this.metricsBuilder = metricsBuilder;
             this.DataProvider = new DefaultDataProvider(context, timestampProvider, this.registry.DataProvider, () => this.childContexts.Values.Select(c => c.DataProvider));
         }
@@ -74,6 +74,8 @@ namespace Metrics.Core
             {
                 throw new ArgumentException("contextName must not be null or empty", contextName);
             }
+
+            EventMetricsCleaner.RemoveRegistry(contextName);
 
             MetricsContext context;
             if (this.childContexts.TryRemove(contextName, out context))

--- a/Src/Metrics/Core/BaseMetricsContext.cs
+++ b/Src/Metrics/Core/BaseMetricsContext.cs
@@ -19,7 +19,7 @@ namespace Metrics.Core
         protected BaseMetricsContext(string context, MetricsRegistry registry, MetricsBuilder metricsBuilder, Func<DateTime> timestampProvider)
         {
             this.registry = registry;
-            EventMetricsCleaner.AddRegistry(context, registry);
+            EventMetricsCleaner.ContextRegistries.Add(context, registry);
             this.metricsBuilder = metricsBuilder;
             this.DataProvider = new DefaultDataProvider(context, timestampProvider, this.registry.DataProvider, () => this.childContexts.Values.Select(c => c.DataProvider));
         }
@@ -75,7 +75,7 @@ namespace Metrics.Core
                 throw new ArgumentException("contextName must not be null or empty", contextName);
             }
 
-            EventMetricsCleaner.RemoveRegistry(contextName);
+            EventMetricsCleaner.ContextRegistries.Remove(contextName);
 
             MetricsContext context;
             if (this.childContexts.TryRemove(contextName, out context))

--- a/Src/Metrics/Reporters/Cleaners/EventMetricsCleaner.cs
+++ b/Src/Metrics/Reporters/Cleaners/EventMetricsCleaner.cs
@@ -23,12 +23,12 @@ namespace Metrics.Reporters.Cleaners
         /// <summary>
         /// Collection of MetricsRegistry objects related to their contexts.
         /// </summary>
-        public static ContextRegistriesWrapper ContextRegistries;
+        public static ContextRegistries ContextRegistries;
 
         static EventMetricsCleaner()
         {
             ReportEventCounts = new ReportEventCounts();
-            ContextRegistries = new ContextRegistriesWrapper();
+            ContextRegistries = new ContextRegistries();
             curInterval = cleanIntervalBuffer;
 
             timer = new ThreadingTimer(null, curInterval, curInterval);
@@ -243,7 +243,7 @@ namespace Metrics.Reporters.Cleaners
     /// <summary>
     /// Collection of MetricsRegistry objects related to their contexts.
     /// </summary>
-    public class ContextRegistriesWrapper
+    public class ContextRegistries
     {
         private readonly Dictionary<string, MetricsRegistry> cntxtRegistry;
 
@@ -260,7 +260,7 @@ namespace Metrics.Reporters.Cleaners
             }
         }
 
-        public ContextRegistriesWrapper()
+        public ContextRegistries()
         {
             this.cntxtRegistry = new Dictionary<string, MetricsRegistry>();
         }

--- a/Src/Metrics/Reporters/Cleaners/EventMetricsCleaner.cs
+++ b/Src/Metrics/Reporters/Cleaners/EventMetricsCleaner.cs
@@ -18,7 +18,7 @@ namespace Metrics.Reporters.Cleaners
         /// <summary>
         /// Collection of reports and their respective counts associated with the events thay have reported.
         /// </summary>
-        public static readonly ReportEventCounts ReportEvntCounts;
+        public static readonly ReportEventCounts ReportEventCounts;
 
         /// <summary>
         /// Collection of MetricsRegistry objects related to their contexts.
@@ -27,7 +27,7 @@ namespace Metrics.Reporters.Cleaners
 
         static EventMetricsCleaner()
         {
-            ReportEvntCounts = new ReportEventCounts();
+            ReportEventCounts = new ReportEventCounts();
             ContextRegistries = new ContextRegistriesWrapper();
             curInterval = cleanIntervalBuffer;
 
@@ -61,7 +61,7 @@ namespace Metrics.Reporters.Cleaners
         {
             get
             {
-                return ReportEvntCounts.Count;
+                return ReportEventCounts.Count;
             }
         }
 
@@ -94,8 +94,8 @@ namespace Metrics.Reporters.Cleaners
                 }
             }
 
-            ReportEvntCounts.Add(new HashSet<EventCount>());
-            return ReportEvntCounts.Count - 1;
+            ReportEventCounts.Add(new HashSet<EventCount>());
+            return ReportEventCounts.Count - 1;
         }
 
         /// <summary>
@@ -105,13 +105,13 @@ namespace Metrics.Reporters.Cleaners
         /// <param name="events">The events reported by the reporter.</param>
         public static void UpdateTotalReportedEvents(int reportIdentifier, IEnumerable<EventValueSource> events)
         {
-            if (reportIdentifier >= 0 && reportIdentifier < ReportEvntCounts.Count)
+            if (reportIdentifier >= 0 && reportIdentifier < ReportEventCounts.Count)
             {
                 foreach (var evntSrc in events)
                 {
                     var count = evntSrc.Value.EventsCopy.Count;
                     var eventMetricId = MetricIdentifier.Calculate(evntSrc.Name, evntSrc.Tags);
-                    var report = ReportEvntCounts[reportIdentifier];
+                    var report = ReportEventCounts[reportIdentifier];
 
                     var eventCount = report.FirstOrDefault(e => e.EventMetricIdentifier == eventMetricId);
                     if (eventCount != null)
@@ -148,7 +148,7 @@ namespace Metrics.Reporters.Cleaners
         /// <param name="eventMetricIdentifier">The unique identifier for the event to remove.</param>
         public static void RemoveEvent(string eventMetricIdentifier)
         {
-            foreach (var eventCount in ReportEvntCounts)
+            foreach (var eventCount in ReportEventCounts)
             {
                 if (!string.IsNullOrWhiteSpace(eventMetricIdentifier))
                 { 
@@ -167,7 +167,7 @@ namespace Metrics.Reporters.Cleaners
                 var registry = kvp.Value;
                 if (registry != null)
                 {
-                    if (ReportEvntCounts.Count == 0)
+                    if (ReportEventCounts.Count == 0)
                     {
                         registry.ClearEventValues();
                         return;
@@ -175,7 +175,7 @@ namespace Metrics.Reporters.Cleaners
 
                     var eventMetricIdentifiers = new HashSet<string>();
                     var lowestNumEventsReported = new Dictionary<string, int>();
-                    foreach (var eventCounts in ReportEvntCounts)
+                    foreach (var eventCounts in ReportEventCounts)
                     {
                         foreach (var eventCount in eventCounts)
                         {


### PR DESCRIPTION
The cleaner needs to be aware of all registries in all contexts.
Added unit tests to confirm that all events get cleared in all registries.